### PR TITLE
#[feature]-allow all the hidden features.

### DIFF
--- a/bin/irc.sh
+++ b/bin/irc.sh
@@ -5,6 +5,8 @@
 set -o errexit
 
 rustc - -o out <<EOF
+#[feature(globs, macro_rules, struct_variant)];
+
 extern mod extra;
 
 static version: &'static str = "$(rustc -v | head -1)";


### PR DESCRIPTION
These can only be activated at the crate level, so it's either there or users of rusti can't use them at all.
