### PR TITLE
Add rmdir/mkdir to whitelist

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -40,6 +40,7 @@ ioctl
 lseek
 lstat
 madvise
+mkdir
 mmap
 mprotect
 mremap
@@ -54,6 +55,7 @@ readlink
 rt_sigaction
 rt_sigprocmask
 rt_sigreturn
+rmdir
 setrlimit
 set_robust_list
 set_tid_address


### PR DESCRIPTION
Once mozilla/rust#11431 lands, rusti will work again with these syscalls.
