### PR TITLE
Cache results and allow sharing of a snippet

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -3,9 +3,9 @@
     <head>
         <title>rust playpen</title>
         <meta charset="utf-8"/>
-        <link rel="stylesheet" href="web.css"/>
+        <link rel="stylesheet" href="/web.css"/>
         <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js" charset="utf-8"></script>
-        <script src="web.js"></script>
+        <script src="/web.js"></script>
     </head>
     <body>
         <div id="editor"></div>

--- a/static/web.js
+++ b/static/web.js
@@ -100,6 +100,21 @@ addEventListener("DOMContentLoaded", function() {
     var query = get_query_parameters();
     if ("code" in query) {
         session.setValue(query["code"]);
+    } else if (window.location.pathname.indexOf("/c/") === 0) {
+        var id = window.location.pathname.substr(3);
+
+        var request = new XMLHttpRequest();
+        request.open("GET", "/raw/" + id, true);
+        request.onreadystatechange = function() {
+            if (request.readyState == 4) {
+                if (request.status == 200) {
+                    session.setValue(request.responseText);
+                } else {
+                    result.textContent = "connection failure";
+                }
+            }
+        }
+        request.send();
     } else {
         var index = Math.floor(Math.random() * samples);
         set_sample(sample, session, result, index);


### PR DESCRIPTION
Cache results and assign a snippet id to each request,
based on the MD5 of the query.
# New routes
- /raw/{snippet id}: GETs the Rust source of a snippet.
- /c/{snippet id}: Shareable snippet.

/evaluate.json, /format.json and /compile.json now return the snippet
id for that request ({ result: "", id: <snippet_id>}).
