### PR TITLE
Allow the evaluate end-point to separate output from compiler

### DIFF
--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -6,4 +6,8 @@ rustc - --opt-level=$1 -o out <<EOF
 $2
 EOF
 
+if [ "$3" = "1" ]; then
+    printf '\377' # 255 in octal
+fi
+
 exec ./out

--- a/playpen.py
+++ b/playpen.py
@@ -2,7 +2,7 @@
 
 import subprocess
 
-def execute(version, command, arguments):
+def execute(version, command, arguments, decode=True):
     with subprocess.Popen(("playpen",
                            "root-" + version,
                            "--mount-proc",
@@ -15,4 +15,6 @@ def execute(version, command, arguments):
                            command) + arguments,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT) as p:
-        return (p.communicate()[0].decode(errors="replace"), p.returncode)
+        out = p.communicate()[0]
+        return (out.decode(errors="replace") if decode else out,
+                p.returncode)


### PR DESCRIPTION
vs. program.

Specifying separate_output=1 in an evaluate request will mean the return
value is then `{ "rustc": <output of the compiler>, "program": <output
of the program> }`.
