### PR TITLE
Implement client-side url shortening with is.gd

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -15,6 +15,7 @@
             <button id="asm">asm</button>
             <button id="ir">ir</button>
             <button id="format">format</button>
+            <button id="share">share</button>
             <select id="optimize">
                 <option value="0">-O0</option>
                 <option value="1">-O1</option>

--- a/static/web.js
+++ b/static/web.js
@@ -56,6 +56,44 @@ function format(result, session, version) {
     });
 }
 
+function share(result, code) {
+    var playurl = "http://play.rust-lang.org?code=" + encodeURIComponent(code);
+    if(playurl.length > 5000) {
+        result.textContent = "resulting URL above character limit for sharing. " +
+            "Length: " + playurl.length + "; Maximum: 5000";
+        return;
+    }
+
+    var url = "http://is.gd/create.php?format=json&url=" + encodeURIComponent(playurl);
+
+    var request = new XMLHttpRequest();
+    request.open("GET", url, true);
+
+    request.onreadystatechange = function() {
+        if (request.readyState == 4) {
+            if (request.status == 200) {
+                setResponse(JSON.parse(request.responseText)['shorturl']);
+            } else {
+                result.textContent = "connection failure";
+            }
+        }
+    }
+
+    request.send();
+
+    function setResponse(shorturl) {
+        while(result.firstChild) {
+            result.removeChild(result.firstChild);
+        }
+
+        var link = document.createElement("a");
+        link.href = link.textContent = shorturl;
+
+        result.textContent = "short url: ";
+        result.appendChild(link);
+    }
+}
+
 function set_sample(sample, session, result, index) {
     var request = new XMLHttpRequest();
     sample.options[index].selected = true;
@@ -89,6 +127,7 @@ addEventListener("DOMContentLoaded", function() {
     var asm_button = document.getElementById("asm");
     var ir_button = document.getElementById("ir");
     var format_button = document.getElementById("format");
+    var share_button = document.getElementById("share");
     var result = document.getElementById("result");
     var optimize = document.getElementById("optimize");
     var version = document.getElementById("version");
@@ -133,5 +172,9 @@ addEventListener("DOMContentLoaded", function() {
 
     format_button.onclick = function() {
         format(result, session, version.options[version.selectedIndex].text);
+    };
+
+    share_button.onclick = function() {
+        share(result, session.getValue());
     };
 }, false);


### PR DESCRIPTION
This addresses #4. It implements URL shortening on the client-side, using the is.gd CORS API.

Some of the pros of the approach:
- Doesn't depend in any way on server-side support (thus the backend can remain stateless)
- Very simple implementation

The cons:
- We depend on a third-party
- The length of the to-be-shortened URL must not exceed 5000 characters. I've made a very crude estimate on the rustc codebase (removing comments, but not blank lines), and found out that this averages to ~158 lines of rust code. It remains to be seen whether this is enough for most uses of the playpen.

If you want to tell me why my estimate is wrong, or just enjoy reading dirty unreadable code for fun, check it out: https://gist.github.com/riccieri/c554e5a4e796ea8c42c2 (uses ruby and [GNU Parallel](https://www.gnu.org/software/parallel/))
