### PR TITLE
Skip the dead code lint for the IRC bot

### DIFF
--- a/bin/irc.sh
+++ b/bin/irc.sh
@@ -6,6 +6,7 @@ set -o errexit
 
 rustc - -o out <<EOF
 #![feature(asm, globs, macro_rules, phase, simd, struct_variant, thread_local, quad_precision_float)]
+#![allow(dead_code)]
 
 extern crate collections;
 extern crate native;
@@ -14,10 +15,8 @@ extern crate rand;
 extern crate regex_macros;
 extern crate regex;
 
-#[allow(dead_code)]
 static version: &'static str = "$(rustc -v | tail | head -1)";
 
-#[allow(dead_code)]
 fn show<T: std::fmt::Show>(e: T) { println!("{}", e) }
 
 fn main() {


### PR DESCRIPTION
It’s normally just noise and is typically a minor nuisance,
so let’s remove it altogether.
