### PR TITLE
Add nanosleep to whitelist

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -41,6 +41,7 @@ mmap
 mprotect
 mremap
 munmap
+nanosleep
 open
 openat
 pipe


### PR DESCRIPTION
The following program doesn't work in play.rust-lang.org:

```
fn main() {std::io::Timer::new().unwrap().sleep(1000);}
```

Running on my machine under strace, it appears the only disallowed syscall is nanosleep.  I don't see a reason it should be prohibited, so I've added it to the whitelist.
