### PR TITLE
adding button styling

### DIFF
--- a/static/web.css
+++ b/static/web.css
@@ -12,6 +12,24 @@
     color: #999;
 }
 
+select,
+button {
+    background-color: white;
+    border: 1px solid #aaa;
+    border-radius: 5px;
+    height: 31px;
+    padding: 5px 10px;
+    font-size: 16px;
+    cursor: pointer;
+    color: #777;
+    margin-right: 5px;
+}
+
+button:hover {
+    background-color: #eee;
+    color: black;
+}
+
 /* Pygments github style */
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #999988; font-style: italic } /* Comment */


### PR DESCRIPTION
Why? Browser default button styles are so small and old-fashioned looking.

Showing the hover styling on the share button.
![image](https://cloud.githubusercontent.com/assets/112170/3595070/84d98fd0-0cae-11e4-83b3-d5ee291a83f9.png)
