### PR TITLE
Check for long lines before partial truncation.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -67,13 +67,13 @@ def evaluate(code, nickname):
     out = out.replace(b"\xff", b"", 1).decode(errors="replace")
     lines = out.splitlines()
 
-    limit = 3
-    if len(lines) > limit:
-        return "\n".join(lines[:limit - 1] + [pastebin(code)])
-
     for line in lines:
         if len(line) > 150:
             return pastebin(code)
+
+    limit = 3
+    if len(lines) > limit:
+        return "\n".join(lines[:limit - 1] + [pastebin(code)])
 
     return out
 


### PR DESCRIPTION
Otherwise someone can make the bot (try to) print a very long line by
ensuring the output is more than 3 lines long, and the long line is
before the cut off, e.g.

```
 println!("{}\n\n\n", "x".repeat(1_000_000));
```
