### PR TITLE
Use `Show` for bot output.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,10 +28,9 @@ static VERSION: &'static str = "%(version)s";
 fn show<T: std::fmt::Show>(e: T) { println!("{:?}", e) }
 
 fn main() {
-    let r = {
+    show({
         %(input)s
-    };
-    println!("{}", r)
+    });
 }"""
 
 def pastebin(command):


### PR DESCRIPTION
It's rather annoying that e.g. expressions returning `()` don't work, this should fix that.