### PR TITLE
Remove regex reference from rusti

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,6 @@ irc_template = """\
 
 extern crate arena;
 extern crate libc;
-extern crate regex;
 
 static VERSION: &'static str = "%(version)s";
 


### PR DESCRIPTION
The regex crate has been moved out of rust to crate.io. So rusti can't
use it as is any more. Removes the reference.