### PR TITLE
Move to HTTPS to stop mixed content error

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -70,7 +70,7 @@ function format(result, session, version) {
 }
 
 function share(result, version, code) {
-    var playurl = "http://play.rust-lang.org?code=" + encodeURIComponent(code);
+    var playurl = "https://play.rust-lang.org?code=" + encodeURIComponent(code);
     if (version != "master") {
         playurl += "&version=" + encodeURIComponent(version);
     }
@@ -80,7 +80,7 @@ function share(result, version, code) {
         return;
     }
 
-    var url = "http://is.gd/create.php?format=json&url=" + encodeURIComponent(playurl);
+    var url = "https://is.gd/create.php?format=json&url=" + encodeURIComponent(playurl);
 
     var request = new XMLHttpRequest();
     request.open("GET", url, true);


### PR DESCRIPTION
https://developer.mozilla.org/docs/Security/MixedContent

Firefox now blocks XHR requests to HTTP sites from HTTPS origins. We do this with the is.gd API call, though their API works on HTTPS too ([demo](https://is.gd/create.php?format=json&url=http%3A%2F%2Fplay.rust-lang.org%3Fcode%3Dfn%2520main%28%29%2520%257B%250A%2520%2520%2520%2520let%2520x%2520%253D%2520StatusCode%28200%29%253B%250A%2520%2520%2520%2520assert!%28x%2520%253D%253D%2520StatusCode%253A%253AOk%29%250A%257D%250A%250A%2523%255Bderive%28PartialEq%29%255D%250Astruct%2520StatusCode%28pub%2520u16%29%253B%250A%250A%2523%255Ballow%28non_snake_case%29%255D%250A%2523%255Ballow%28non_upper_case_globals%29%255D%250Amod%2520StatusCode%2520%257B%250A%2520%2520use%2520super%253A%253AStatusCode%253B%250A%2520%2520pub%2520static%2520Ok%253A%2520StatusCode%2520%253D%2520StatusCode%28200%29%253B%250A%250A%257D))