### PR TITLE
Added theme support to the frontend using Ace themes.

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -6,6 +6,7 @@
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <link rel="stylesheet" href="web.css"/>
         <script src="//cdn.jsdelivr.net/ace/1.1.8/min/ace.js" charset="utf-8"></script>
+        <script src="//cdn.jsdelivr.net/ace/1.1.8/min/ext-themelist.js" charset="utf-8"></script>
         <script src="web.js"></script>
     </head>
     <body>
@@ -28,6 +29,8 @@
                 <option>Ace</option>
                 <option>Emacs</option>
                 <option>Vim</option>
+            </select>
+            <select id="themes">
             </select>
         </p>
         <div id="editor">fn main() {


### PR DESCRIPTION
This uses Ace's `ext-themelist.js` and `localStorage` to set and remember the user's favorite highlighting theme. It adds one `<select>` tag on the end of the others. All themes are listed alphabetically by their proper name. The default theme is still `GitHub`. 

I've tested this locally using Chrome and `web.py`. Since it only touches the frontend it shouldn't interfere with any of the actual code evaluation.

This is what it looks like:
![image](https://cloud.githubusercontent.com/assets/3343802/6156195/ab1d950c-b1fd-11e4-9aa1-bd0e2369b78f.png)
