### PR TITLE
catch possible errors from localStorage

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -174,7 +174,10 @@ function set_theme(editor, themelist, theme) {
     }
     if (themepath !== null) {
         editor.setTheme(themepath);
-        localStorage.setItem("theme", theme);
+        try {
+            localStorage.setItem("theme", theme);
+        } catch(e) {
+        }
     }
 }
 
@@ -195,7 +198,11 @@ addEventListener("DOMContentLoaded", function() {
 
     build_themes(themelist);
 
-    var theme = localStorage.getItem("theme");
+    try {
+        var theme = localStorage.getItem("theme");
+    } catch(e) {
+        var theme = null;
+    }
     if (theme === null) {
         set_theme(editor, themelist, "GitHub");
     } else {
@@ -204,19 +211,25 @@ addEventListener("DOMContentLoaded", function() {
 
     session.setMode("ace/mode/rust");
 
-    var mode = localStorage.getItem("keyboard");
-    if (mode !== null) {
-        set_keyboard(editor, mode);
-        keyboard.value = mode;
+    try {
+        var mode = localStorage.getItem("keyboard");
+        if (mode !== null) {
+            set_keyboard(editor, mode);
+            keyboard.value = mode;
+        }
+    } catch(e) {
     }
 
     var query = getQueryParameters();
     if ("code" in query) {
         session.setValue(query["code"]);
     } else {
-        var code = localStorage.getItem("code");
-        if (code !== null) {
-            session.setValue(code);
+        try {
+            var code = localStorage.getItem("code");
+            if (code !== null) {
+                session.setValue(code);
+            }
+        } catch(e) {
         }
     }
 
@@ -230,12 +243,18 @@ addEventListener("DOMContentLoaded", function() {
     }
 
     session.on("change", function() {
-        localStorage.setItem("code", session.getValue());
+        try {
+            localStorage.setItem("code", session.getValue());
+        } catch(e) {
+        }
     });
 
     keyboard.onchange = function() {
         var mode = keyboard.options[keyboard.selectedIndex].value;
-        localStorage.setItem("keyboard", mode);
+        try {
+            localStorage.setItem("keyboard", mode);
+        } catch(e) {
+        }
         set_keyboard(editor, mode);
     }
 

--- a/static/web.js
+++ b/static/web.js
@@ -2,6 +2,22 @@
 
 var samples = 2;
 
+function optionalLocalStorageGetItem(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch(e) {
+        return null;
+    }
+}
+
+function optionalLocalStorageSetItem(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch(e) {
+        // ignore
+    }
+}
+
 function build_themes(themelist) {
     // Load all ace themes, sorted by their proper name.
     var themes = themelist.themes;
@@ -174,10 +190,7 @@ function set_theme(editor, themelist, theme) {
     }
     if (themepath !== null) {
         editor.setTheme(themepath);
-        try {
-            localStorage.setItem("theme", theme);
-        } catch(e) {
-        }
+        optionalLocalStorageSetItem("theme", theme);
     }
 }
 
@@ -198,11 +211,7 @@ addEventListener("DOMContentLoaded", function() {
 
     build_themes(themelist);
 
-    try {
-        var theme = localStorage.getItem("theme");
-    } catch(e) {
-        var theme = null;
-    }
+    var theme = optionalLocalStorageGetItem("theme");
     if (theme === null) {
         set_theme(editor, themelist, "GitHub");
     } else {
@@ -211,25 +220,19 @@ addEventListener("DOMContentLoaded", function() {
 
     session.setMode("ace/mode/rust");
 
-    try {
-        var mode = localStorage.getItem("keyboard");
-        if (mode !== null) {
-            set_keyboard(editor, mode);
-            keyboard.value = mode;
-        }
-    } catch(e) {
+    var mode = optionalLocalStorageGetItem("keyboard");
+    if (mode !== null) {
+        set_keyboard(editor, mode);
+        keyboard.value = mode;
     }
 
     var query = getQueryParameters();
     if ("code" in query) {
         session.setValue(query["code"]);
     } else {
-        try {
-            var code = localStorage.getItem("code");
-            if (code !== null) {
-                session.setValue(code);
-            }
-        } catch(e) {
+        var code = optionalLocalStorageGetItem("code");
+        if (code !== null) {
+            session.setValue(code);
         }
     }
 
@@ -243,18 +246,12 @@ addEventListener("DOMContentLoaded", function() {
     }
 
     session.on("change", function() {
-        try {
-            localStorage.setItem("code", session.getValue());
-        } catch(e) {
-        }
+        optionalLocalStorageSetItem("code", session.getValue());
     });
 
     keyboard.onchange = function() {
         var mode = keyboard.options[keyboard.selectedIndex].value;
-        try {
-            localStorage.setItem("keyboard", mode);
-        } catch(e) {
-        }
+        optionalLocalStorageSetItem("keyboard", mode);
         set_keyboard(editor, mode);
     }
 


### PR DESCRIPTION
allow webkit browser with disabled localStorage (localStorage is `null`)
or private-browsing enable (throw `QUOTA_EXCEEDED_ERR`) to use
rust-playpen.