### PR TITLE
Ace update v.1.1.9, Fixes #77

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -5,8 +5,8 @@
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <link rel="stylesheet" href="web.css"/>
-        <script src="//cdn.jsdelivr.net/ace/1.1.8/min/ace.js" charset="utf-8"></script>
-        <script src="//cdn.jsdelivr.net/ace/1.1.8/min/ext-themelist.js" charset="utf-8"></script>
+        <script src="//cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
+        <script src="//cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
         <script src="web.js"></script>
     </head>
     <body>


### PR DESCRIPTION
Ace released a new version that fixes several rust highlight problems ( Issue #77 is one of them). This PR simply switches to the new version. Tested locally with web.py.