### PR TITLE
Use the rust-lang.org favicon

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <link rel="stylesheet" href="web.css"/>
+        <link rel="shortcut icon" href="http://www.rust-lang.org/favicon.ico"/>
         <script src="//cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
         <script src="//cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
         <script src="web.js"></script>


### PR DESCRIPTION
Maybe it should have its own, but I just linked in the one on rust-lang.org