### PR TITLE
Remove the format button for now.

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -17,10 +17,10 @@
 				><button type=button id=asm title="Compile to ASM">ASM</button
 				><button type=button id=llvm-ir title="Compile to LLVM IR">LLVM IR</button
 			></div
-			><wbr><div
+			><!--<wbr><div
 				><button type=button id=format title="Automatically visually reformat your code">Format</button
 			></div
-			><wbr><div
+			>--><wbr><div
 				><button type=button id=share title="Share a link to your code">Share</button
 			></div
 			><wbr><div class=radios


### PR DESCRIPTION
The formatting is just `rustc --pretty`, which is known to be subpar and
unidiomatic. This could be reintroduced with rustfmt.