### PR TITLE
Gist integration, part 1

### DIFF
--- a/static/web.css
+++ b/static/web.css
@@ -124,7 +124,7 @@
     margin-right: 0.5em;
 }
 
-#share { /* The last of the buttons, put in a little more space */
+#gist { /* The last of the buttons, put in a little more space */
     margin-right: 0.5em;
 }
 

--- a/static/web.html
+++ b/static/web.html
@@ -25,7 +25,8 @@
 				><button type=button id=format title="Automatically visually reformat your code">Format</button
 			></div
 			>--><wbr><div
-				><button type=button id=share title="Share a link to your code">Share</button
+				><button type=button id=share title="Share a link to your code via is.gd">Shorten</button
+        ><button type=button id=gist title="Share a link to your code via Gist">Gist</button
 			></div
 			><wbr><div class=radios
 				><div title="Select a build mode:

--- a/static/web.html
+++ b/static/web.html
@@ -26,7 +26,7 @@
 			></div
 			>--><wbr><div
 				><button type=button id=share title="Share a link to your code via is.gd">Shorten</button
-        ><button type=button id=gist title="Share a link to your code via Gist">Gist</button
+				><button type=button id=gist title="Share a link to your code via Gist">Gist</button
 			></div
 			><wbr><div class=radios
 				><div title="Select a build mode:

--- a/static/web.js
+++ b/static/web.js
@@ -238,6 +238,7 @@ function share(result, version, code, button) {
     httpRequest("GET", url, null, 200,
                 function(response) {
                     clearInterval(repainter);
+                    button.disabled = false;
 
                     var link = result.firstChild.firstElementChild;
                     link.className = "";
@@ -247,6 +248,7 @@ function share(result, version, code, button) {
                 },
                 function(status, response) {
                     clearInterval(repainter);
+                    button.disabled = false;
 
                     set_result(result, "<p class=error>Connection failure" +
                         "<p class=error-explanation>Are you connected to the Internet?");
@@ -254,9 +256,6 @@ function share(result, version, code, button) {
                     repaint();
                 }
     );
-}
->>>>>>> Add separate HTTP request function and refactor share()
-
 }
 
 function getQueryParameters() {


### PR DESCRIPTION
This PR adds support for sharing the session via an anonymous Gist.  It changes the 'Share' button to 'Shorten' and adds a 'Gist' button next to it. A new query parameter 'gist' specifies the Gist ID to load.

A Gist-Playground URL looks like this:
[https://play.rust-lang.org/?gist=b5552ad8232f90e3380b&version=stable](https://play.rust-lang.org/?gist=b5552ad8232f90e3380b&version=stable)

Gists with multiple files aren't supported; this will just load the first file it encounters.

This also adds a new function 'httpRequest'.  Unfortunately I didn't notice the existing 'send' function, however that was too restrictive to begin with.  I'll make a separate PR that merges these functions in some way so we don't have any silly repeated code for requesting things.


It's "Part 1" because I would also like to add support for forking/revisions (as seen in the typical flow on #rust of question with link -> answer with revised link).  Included in this will be the ability to authenticate with GitHub, instead of using the API anonymously.