### PR TITLE
[WIP] Add testing mode

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -C opt-level=$1 --emit=$2 -o ./out
+rustc - -C opt-level=$1 --emit=$2 $3 -o ./out
 printf '\377' # 255 in octal
 exec cat out

--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -C opt-level=$1 -o ./out
+rustc - -C opt-level=$1 $2 -o ./out
 printf '\377' # 255 in octal
 exec ./out

--- a/static/web.html
+++ b/static/web.html
@@ -38,6 +38,14 @@
 				></div
 			></div
 			><wbr><div class=radios
+				><div title="Select whether to run in test mode or not
+				">Test Mode</div
+				><div
+					><input type=radio name=test id=test-yes value=test-yes><label for=test-yes title="Use test">On</label
+					><input type=radio name=test id=test-no value=test-no checked><label for=test-no title="Don't test">Off</label
+				></div
+			></div
+			><wbr><div class=radios
 				><div title="Select which version of rustc to use:
  · Stable: use this normally; stable features only.
  · Beta: the next version; stable features only.

--- a/static/web.js
+++ b/static/web.js
@@ -129,8 +129,8 @@ function redrawResult(result) {
     result.parentNode.style.visibility = "";
 }
 
-function evaluate(result, code, version, optimize, button) {
-    send("evaluate.json", {code: code, version: version, optimize: optimize, separate_output: true},
+function evaluate(result, code, version, optimize, button, test) {
+    send("evaluate.json", {code: code, version: version, optimize: optimize, separate_output: true, test: test},
         function(object) {
             var samp = document.createElement("samp");
             samp.className = ("program" in object) ? "rustc-warnings" : "rustc-errors";
@@ -154,9 +154,9 @@ function evaluate(result, code, version, optimize, button) {
     }, button, "Running…", result);
 }
 
-function compile(emit, result, code, version, optimize, button) {
+function compile(emit, result, code, version, optimize, button, test) {
     send("compile.json", {emit: emit, code: code, version: version, optimize: optimize,
-                          highlight: true}, function(object) {
+                          highlight: true, test: test}, function(object) {
         if ("error" in object) {
             set_result(result, "<pre class=highlight><samp class=rustc-errors></samp></pre>");
             result.firstChild.firstChild.textContent = object["error"];
@@ -520,7 +520,7 @@ addEventListener("DOMContentLoaded", function() {
 
     evaluateButton.onclick = function() {
         evaluate(result, session.getValue(), getRadioValue("version"),
-                 getRadioValue("optimize"), evaluateButton);
+                 getRadioValue("optimize"), evaluateButton, getRadioValue("test")=="test-yes");
     };
 
     editor.commands.addCommand({
@@ -538,12 +538,12 @@ addEventListener("DOMContentLoaded", function() {
 
     asmButton.onclick = function() {
         compile("asm", result, session.getValue(), getRadioValue("version"),
-                 getRadioValue("optimize"), asmButton);
+                 getRadioValue("optimize"), asmButton, getRadioValue("test")=="test-yes");
     };
 
     irButton.onclick = function() {
         compile("llvm-ir", result, session.getValue(), getRadioValue("version"),
-                 getRadioValue("optimize"), irButton);
+                 getRadioValue("optimize"), irButton, getRadioValue("test")=="test-yes");
     };
 
     /*

--- a/web.py
+++ b/web.py
@@ -62,7 +62,12 @@ def extractor(key, default, valid):
 @extractor("version", "stable", ("stable", "beta", "nightly"))
 @extractor("optimize", "2", ("0", "1", "2", "3"))
 def evaluate(optimize, version):
-    out, _ = execute(version, "/usr/local/bin/evaluate.sh", (optimize,), request.json["code"])
+    if request.json.get("test") is True:
+        options = (optimize,"--test")
+    else:
+        options = (optimize,)
+
+    out, _ = execute(version, "/usr/local/bin/evaluate.sh", options, request.json["code"])
 
     if request.json.get("separate_output") is True:
         split = out.split(b"\xff", 1)
@@ -92,7 +97,12 @@ def format(version):
 @extractor("optimize", "2", ("0", "1", "2", "3"))
 @extractor("emit", "asm", ("asm", "llvm-ir"))
 def compile(emit, optimize, version):
-    out, rc = execute(version, "/usr/local/bin/compile.sh", (optimize, emit), request.json["code"])
+    if request.json.get("test") is True:
+        options = (optimize,emit,"--test")
+    else:
+        options = (optimize,emit)
+
+    out, rc = execute(version, "/usr/local/bin/compile.sh", options, request.json["code"])
     split = out.split(b"\xff", 1)
     if rc:
         return {"error": split[0].decode()}


### PR DESCRIPTION
This is a quick hack to enable `--test` support in the Playpen.
As @ranma42 didn't follow-up in #32 I took half an hour to implement this.

* It's a radio button, so that ASM and LLVM IR work without a main function, too
* Not sure about the naming, currently named `Test Mode` with options `On` and `Off` (default)

![rust playpen test mode](https://tmp.fnordig.de/scr/56829c2533.png)

#98 has more ideas, but the ideas there should go into an `advanced configuration` menu while test mode would be useful to have accessible.

Wanted to get it out there, I can clean up the code later if necessary if this PR is to be accepted.