### PR TITLE
Add link to rust documentation

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -49,6 +49,7 @@
 				></div
 			></div
 			><wbr><div class=right-c-e
+				><a href="https://doc.rust-lang.org/" target="_blank"><span>Documentation</span></a
 				><button type=button id=configure-editor><span>Configure editor</span></button
 				><div class=dropdown>
 					<p><label for=keyboard>Keyboard bindings:</label>


### PR DESCRIPTION
This is my prototype for addressing issue #117.
I have not added any css rules, which would probably be necessary for the Documentation link to be visually pleasing.
Also, the destination of the link might as well go to the rust book instead.
Anyway, have a look at https://anaran.github.io/rust-playpen/static/web.html for what this pull request currently does.
If there's interest I would be happy to make adjustments and squash this into something that can be merged.
