### PR TITLE
Improve compiler output with things like colours.

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -C opt-level=$1 --emit=$2 -o ./out
+rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec cat out

--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -C opt-level=$1 $2 -o ./out
+rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec ./out

--- a/static/web.css
+++ b/static/web.css
@@ -36,16 +36,8 @@
     color: #931;
 }
 
-.rustc-errors {
-    color: #931;
-}
-
-.rustc-warnings {
-    color: #971;
-}
-
 /* #971 works well enough on light or dark, but #931 is just a bit too icky on Solarized Dark */
-.ace_dark .error, .ace_dark .rustc-errors {
+.ace_dark .error {
     color: #a42;
 }
 
@@ -532,3 +524,30 @@ button[disabled]:last-child::before {
 :root .ace-github .ace_marker-layer .ace_stack { background: rgba(164, 229, 101, 0.8); }
 :root .ace-github .ace_marker-layer .ace_selected-word { background: rgba(245, 245, 255, 0.5); }
 :root .ace-github .ace_print-margin { background: rgba(209, 209, 209, 0.5); }
+
+/* rustc output. bright versions of red, yellow, green, cyan and magenta are used, but black, blue and gray could theoretically be added with dim versions of them. */
+.rustc-output {
+	white-space: pre-wrap;
+	padding-bottom: 1em;
+	border-bottom: 1px dashed rgba(0, 0, 0, 0.25);
+}
+
+.ace_dark .rustc-output {
+	border-bottom-color: rgba(255, 255, 255, 0.25);
+}
+
+.rustc-output:last-child {
+	border-bottom: none;
+	padding-bottom: none;
+}
+
+.ansi-red     { color: #a00; }
+.ansi-green   { color: #0a0; }
+.ansi-yellow  { color: #980; }
+.ansi-magenta { color: #a0a; }
+.ansi-cyan    { color: #096; }
+.ace_dark .ansi-red     { color: #f55; }
+.ace_dark .ansi-green   { color: #5f5; }
+.ace_dark .ansi-yellow  { color: #ff5; }
+.ace_dark .ansi-magenta { color: #f5f; }
+.ace_dark .ansi-cyan    { color: #5ff; }

--- a/static/web.html
+++ b/static/web.html
@@ -8,11 +8,11 @@
         <script>if (screen.width > 720) { document.getElementById("meta-viewport").setAttribute('content', 'width=device-width'); }</script>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
-        <link rel="stylesheet" href="web.css?4">
+        <link rel="stylesheet" href="web.css?5">
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
-        <script src="web.js?6"></script>
+        <script src="web.js?7"></script>
     </head>
     <body>
         <form id="control">


### PR DESCRIPTION
The compiler can write ANSI colour codes for nicer error messages, so why not use it? I improved a few other cases (like internal server errors which I unsurprisingly triggered while developing—reporting such as connection failures was wrong) while I was at it.

The colour part of it is mildly fragile, as what codes actually get written depends on the terminfo. Most notably, the `^[(B` that seems to come after `^[[m` (turn off all attributes) has baffled me as I haven’t found documentation of what it is, nor do I find it in my termcap for sgr0. Ah well. It doesn’t seem to matter. Hopefully the deployment server will produce the same ANSI codes. If it doesn’t, the ansi2html function may need to be adjusted.

Error codes are hyperlinks to their entries in the error index, which is generated from the same stuff that the hitherto advised `rustc --explain E0000` is.

As usual, http://temp.chrismorgan.info/rust-playpen/static/web.html is running the latest client side code; the colouring depends on server changes, though, so that part won’t be visible yet.