### PR TITLE
Set TERM=xterm to get colours working well.

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -o ./out "$@"
+TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec cat out

--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-rustc - -o ./out "$@"
+TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec ./out

--- a/static/web.html
+++ b/static/web.html
@@ -12,7 +12,7 @@
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
-        <script src="web.js?7"></script>
+        <script src="web.js?8"></script>
     </head>
     <body>
         <form id="control">

--- a/static/web.js
+++ b/static/web.js
@@ -500,28 +500,21 @@
     // This is very basic, with lots of very obvious omissions and holes;
     // it’s designed purely to cope with rustc output.
     //
-    // rustc uses:
+    // TERM=xterm rustc uses these:
     //
-    // - bug/fatal/error = bright red
-    // - warning = bright yellow
-    // - note = bright green
-    // - help = bright cyan
-    // - error code = bright magenta
+    // - bug/fatal/error = red
+    // - warning = yellow
+    // - note = green
+    // - help = cyan
+    // - error code = magenta
     // - bold
     function ansi2html(text) {
         return text.replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
-            .replace(/\x1b\[38;5;(\d+)m([^\x1b]*)\x1b\[m(?:\x1b\(B)?/g, function(original, colorCode, text) {
-                colorCode = +colorCode;
-                if (colorCode < 8) {
-                    return '<span class=ansi-' + colorCode + '>' + text + '</span>';
-                } else if (colorCode < 16) {
-                    return '<span class="ansi-bright ansi-' + COLOR_CODES[colorCode - 8] + '">' + text + '</span>';
-                } else {
-                    return original;
-                }
-            }).replace(/\x1b\[1m([^\x1b]*)\x1b\[m(?:\x1b\(B)?/g, function(original, text) {
+            .replace(/\x1b\[3([0-7])m([^\x1b]*)(?:\x1b\(B)?\x1b\[m/g, function(original, colorCode, text) {
+                return '<span class=ansi-' + COLOR_CODES[+colorCode] + '>' + text + '</span>';
+            }).replace(/\x1b\[1m([^\x1b]*)(?:\x1b\(B)?\x1b\[m/g, function(original, text) {
                 return "<strong>" + text + "</strong>";
             });
     }


### PR DESCRIPTION
This should make colour codes actually work on the server (where `TERM` is presumably unset, based on the experience of landing #121) and ensures stability for the colour codes emitted, constraining it to the basic 16 colour palette which is easier to deal with and more familiar to people (`^[[31m` for red, &c.).

That unknown `^[(B` still appears, though now it’s *before* the `^[[m`, unlike after as it was with my own `TERM=rxvt-unicode-256color`. *Shrug.*