### PR TITLE
Add support for intel syntax when emitting asm

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -59,6 +59,10 @@
 					</select>
 					<p><label for=themes>Theme:</label>
 					<select name=themes id=themes></select>
+					<select name=asm-flavor id=asm-flavor>
+						<option>att</option>
+						<option>intel</option>
+					</select>
 				</div
 			></div>
         </form>

--- a/static/web.js
+++ b/static/web.js
@@ -166,8 +166,9 @@
     }
 
     function compile(emit, result, code, version, optimize, button) {
+        var syntax = $('#asm-syntax').value;
         send("compile.json", {emit: emit, code: code, version: version, optimize: optimize,
-                              color: true, highlight: true}, function(object) {
+                              color: true, highlight: true, syntax: syntax}, function(object) {
             if ("error" in object) {
                 set_result(result, "<pre class=\"rustc-output rustc-errors\"><samp></samp></pre>");
                 result.firstChild.firstChild.innerHTML = formatCompilerOutput(object.error);

--- a/web.py
+++ b/web.py
@@ -96,14 +96,18 @@ def format(version):
 
 @route("/compile.json", method=["POST", "OPTIONS"])
 @enable_post_cors
+@extractor("syntax", "att", ("att", "intel"))
 @extractor("color", False, (True, False))
 @extractor("version", "stable", ("stable", "beta", "nightly"))
 @extractor("optimize", "2", ("0", "1", "2", "3"))
 @extractor("emit", "asm", ("asm", "llvm-ir"))
-def compile(emit, optimize, version, color):
+def compile(emit, optimize, version, color, syntax):
     args = ["-C", "opt-level=" + optimize, "--emit=" + emit]
     if color:
         args.append("--color=always")
+    if syntax:
+        args.append("-C")
+        args.append("llvm-args=-x86-asm-syntax=%s" % syntax)
     out, _ = execute(version, "/usr/local/bin/compile.sh", tuple(args), request.json["code"])
     split = out.split(b"\xff", 1)
     if len(split) == 2:


### PR DESCRIPTION
Confirmed that `-C llvm-args=-x86-asm-syntax=intel` is harmless when emitting IR.