### PR TITLE
Fix for changing themes in IE

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -665,7 +665,7 @@
         };
 
         themes.onkeyup = themes.onchange = function () {
-            set_theme(editor, themelist, themes.selectedOptions[0].text);
+            set_theme(editor, themelist, themes.options[themes.selectedIndex].text);
         };
 
     }, false);


### PR DESCRIPTION
selectedOptions is not supported in Internet Explorer

I've tested this change locally in FF, Chrome, and IE.