### PR TITLE
Fix link shortening.

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -12,7 +12,7 @@
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
-        <script src="web.js?8"></script>
+        <script src="web.js?9"></script>
     </head>
     <body>
         <form id="control">

--- a/static/web.js
+++ b/static/web.js
@@ -293,7 +293,7 @@
     }
 
     function share(result, version, code, button) {
-        var playurl = "https://play.rust-lang.org?code=" + encodeURIComponent(code);
+        var playurl = "https://play.rust-lang.org/?code=" + encodeURIComponent(code);
         playurl += "&version=" + encodeURIComponent(version);
         if (playurl.length > 5000) {
             set_result(result, "<p class=error>Sorry, your code is too long to share this way." +


### PR DESCRIPTION
Although not the canonical form, an empty path is a legal URL according
to RFC 3986; however, is.gd has started rejecting it some time in the
past few days, so let’s go with the canonical form which does work
rather than saving three characters (when URL encoded) out of our quota
of five thousand.