### PR TITLE
Give <main> a definite flex basis (fixes #112)

### DIFF
--- a/static/web.css
+++ b/static/web.css
@@ -462,6 +462,7 @@ button[disabled]:last-child::before {
         border: 3px solid rgba(153, 153, 153, 0.5);
         border-radius: 5px;
         overflow-y: auto;
+        height: 100%;
     }
 
     #editor, #result {


### PR DESCRIPTION
The flexbox spec changed, so that if we want #editor and #result to cover 60 %
and 40 % of the code box, we need to give their parent a size that can be
determined without measuring content.

Chromium has already updated their implementation, making the Playpen really
annoying to use, and Firefox will update theirs eventually.