### PR TITLE
Support standard `ansi2html` escape delimiter

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -523,9 +523,9 @@
         return text.replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
-            .replace(/\x1b\[3([0-7])m([^\x1b]*)(?:\x1b\(B)?\x1b\[m/g, function(original, colorCode, text) {
+            .replace(/\x1b\[3([0-7])m([^\x1b]*)(?:\x1b\(B)?\x1b\[0?m/g, function(original, colorCode, text) {
                 return '<span class=ansi-' + COLOR_CODES[+colorCode] + '>' + text + '</span>';
-            }).replace(/\x1b\[1m([^\x1b]*)(?:\x1b\(B)?\x1b\[m/g, function(original, text) {
+            }).replace(/\x1b\[1m([^\x1b]*)(?:\x1b\(B)?\x1b\[0?m/g, function(original, text) {
                 return "<strong>" + text + "</strong>";
             });
     }


### PR DESCRIPTION
I did a bit of research, and `[0m` seems to be the standard "reset format" ANSI token. I can't find much information on using a simple `[m` instead, but it must is supported by many terminals.

Anyway, rustc switched from `[m` to `[0m` in a recent nightly. This broke `ansi2html`'s regex, which was only expecting `[m`.

This should address and close #157.