### PR TITLE
Show an alert before unload the page

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -505,6 +505,12 @@
                  evaluateAction === "test");
     }
 
+    function addEditedCodeAlert() {
+      window.onbeforeunload = function() {
+        return 'If you leave this page you will lose your changes.';
+      };
+    }
+
     var COLOR_CODES = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
 
     // A simple function to decode ANSI escape codes into HTML.
@@ -622,6 +628,7 @@
             var code = session.getValue();
             optionalLocalStorageSetItem("code", code);
             updateEvaluateAction(code);
+            addEditedCodeAlert();
         });
 
         keyboard.onkeyup = keyboard.onchange = function() {


### PR DESCRIPTION
If you are playing with Rust and you leave accidentally the page you will
lose all your work if you have not save it. This could be annoying. Just
show an alert to confirm that.