### PR TITLE
Update CSS to Fix Layout in Safari

### DIFF
--- a/static/web.css
+++ b/static/web.css
@@ -402,8 +402,11 @@ button[disabled]:last-child::before {
 #control, #editor, #result {
     position: absolute;
     box-sizing: border-box;
+    width: initial;
     width: unset;
+    height: initial;
     height: unset;
+    margin: initial;
     margin: unset;
     left: 16px;
     right: 16px;
@@ -426,6 +429,7 @@ button[disabled]:last-child::before {
 }
 
 #result[data-empty] {
+    bottom: initial;
     bottom: unset;
 }
 
@@ -434,9 +438,13 @@ button[disabled]:last-child::before {
 
     #control, #editor, #result {
         position: relative;
+        left: initial;
         left: unset;
+        right: initial;
         right: unset;
+        top: initial;
         top: unset;
+        bottom: initial;
         bottom: unset;
     }
 


### PR DESCRIPTION
In Safari (and therefor on iOS), the playpen layout in broken: There is a large gap between the code editor and the compiler output.

Safari does not support the `unset` value of CSS3. Adding a fallback to `initial` seems to work for now.

This is kind of a drive-by PR. I have only tested it locally in Safari 9 and Chrome 48 (both by editing the CSS in the dev tools) and haven't had the chance to see its effects in Firefox.