### PR TITLE
Allow printing MIR

### DIFF
--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -5,10 +5,10 @@ set -o errexit
 TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 if [ "${*#*--test}" != "$*" ] && [ "${*#*--color=always}" != "$*" ]; then
-        # For /evaluate.json, we have {test: true, color: true}. Let's make the
-        # output coloured too.  This would be better in web.py, but we don't
-        # have an easy way to allot parameters for ./out.
-	TERM=xterm exec ./out --color=always
+    # For /evaluate.json, we have {test: true, color: true}. Let's make the
+    # output coloured too.  This would be better in web.py, but we don't
+    # have an easy way to allot parameters for ./out.
+    TERM=xterm exec ./out --color=always
 else
-	exec ./out
+    exec ./out
 fi

--- a/init.sh
+++ b/init.sh
@@ -35,10 +35,10 @@ cp -a root-nightly.new root-stable.new
 
 curl -O https://static.rust-lang.org/rustup.sh
 for channel in stable beta nightly; do
-	sh rustup.sh --prefix=root-${channel}.new --channel=$channel --yes
-	[[ -d root-$channel ]] && mv root-$channel root-${channel}.old
-	mv root-${channel}.new root-$channel
-	[[ -d root-${channel}.old ]] && rm -rf root-${channel}.old
-	arch-chroot root-$channel cargo install --root /usr rustfmt
+    sh rustup.sh --prefix=root-${channel}.new --channel=$channel --yes
+    [[ -d root-$channel ]] && mv root-$channel root-${channel}.old
+    mv root-${channel}.new root-$channel
+    [[ -d root-${channel}.old ]] && rm -rf root-${channel}.old
+    arch-chroot root-$channel cargo install --root /usr rustfmt
 done
 rm rustup.sh

--- a/static/web.css
+++ b/static/web.css
@@ -536,18 +536,18 @@ button[disabled]:last-child::before {
 
 /* rustc output. bright versions of red, yellow, green, cyan and magenta are used, but black, blue and gray could theoretically be added with dim versions of them. */
 .rustc-output {
-	white-space: pre-wrap;
-	padding-bottom: 1em;
-	border-bottom: 1px dashed rgba(0, 0, 0, 0.25);
+    white-space: pre-wrap;
+    padding-bottom: 1em;
+    border-bottom: 1px dashed rgba(0, 0, 0, 0.25);
 }
 
 .ace_dark .rustc-output {
-	border-bottom-color: rgba(255, 255, 255, 0.25);
+    border-bottom-color: rgba(255, 255, 255, 0.25);
 }
 
 .rustc-output:last-child {
-	border-bottom: none;
-	padding-bottom: none;
+    border-bottom: none;
+    padding-bottom: none;
 }
 
 .ansi-red     { color: #a00; }

--- a/static/web.html
+++ b/static/web.html
@@ -12,7 +12,7 @@
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
         <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
-        <script src="web.js?10"></script>
+        <script src="web.js?11"></script>
     </head>
     <body>
         <form id="control">
@@ -20,6 +20,9 @@
                 ><button type=button class=primary id=evaluate title="Execute your code (you can also press Ctrl+Enter when editing code)">Run</button
                 ><button type=button id=asm title="Compile to ASM">ASM</button
                 ><button type=button id=llvm-ir title="Compile to LLVM IR">LLVM IR</button
+                ><button type=button id=mir title="Print compiler-internal MIR of the crate
+
+Note that MIR is an unstable implementation detail that's subject to change">MIR</button
             ></div
             ><wbr><div
                 ><button type=button id=format title="Automatically visually reformat your code">Format</button

--- a/static/web.html
+++ b/static/web.html
@@ -16,56 +16,56 @@
     </head>
     <body>
         <form id="control">
-			<div
-				><button type=button class=primary id=evaluate title="Execute your code (you can also press Ctrl+Enter when editing code)">Run</button
-				><button type=button id=asm title="Compile to ASM">ASM</button
-				><button type=button id=llvm-ir title="Compile to LLVM IR">LLVM IR</button
-			></div
-			><wbr><div
-				><button type=button id=format title="Automatically visually reformat your code">Format</button
-			></div
-			><wbr><div
-				><button type=button id=share title="Share a link to your code via is.gd">Shorten</button
-				><button type=button id=gist title="Share a link to your code via Gist">Gist</button
-			></div
-			><wbr><div class=radios
-				><div title="Select a build mode:
+            <div
+                ><button type=button class=primary id=evaluate title="Execute your code (you can also press Ctrl+Enter when editing code)">Run</button
+                ><button type=button id=asm title="Compile to ASM">ASM</button
+                ><button type=button id=llvm-ir title="Compile to LLVM IR">LLVM IR</button
+            ></div
+            ><wbr><div
+                ><button type=button id=format title="Automatically visually reformat your code">Format</button
+            ></div
+            ><wbr><div
+                ><button type=button id=share title="Share a link to your code via is.gd">Shorten</button
+                ><button type=button id=gist title="Share a link to your code via Gist">Gist</button
+            ></div
+            ><wbr><div class=radios
+                ><div title="Select a build mode:
  · Debug: no optimizations; debug assertions on
  · Release: all optimizations; debug assertions off">Mode</div
-				><div
-					><input type=radio name=optimize id=optimize-0 value=0 checked><label for=optimize-0 title="No optimizations, debug assertions on. This is the default for rustc and cargo invocations and is good for development.">Debug</label
-					><input type=radio name=optimize id=optimize-3 value=3><label for=optimize-3 title="All optimizations, debug assertions off. Equivalent to `rustc -C opt-level 3` or `cargo --release`.">Release</label
-				></div
-			></div
-			><wbr><div class=radios
-				><div title="Select which version of rustc to use:
+                ><div
+                    ><input type=radio name=optimize id=optimize-0 value=0 checked><label for=optimize-0 title="No optimizations, debug assertions on. This is the default for rustc and cargo invocations and is good for development.">Debug</label
+                    ><input type=radio name=optimize id=optimize-3 value=3><label for=optimize-3 title="All optimizations, debug assertions off. Equivalent to `rustc -C opt-level 3` or `cargo --release`.">Release</label
+                ></div
+            ></div
+            ><wbr><div class=radios
+                ><div title="Select which version of rustc to use:
  · Stable: use this normally; stable features only.
  · Beta: the next version; stable features only.
  · Nightly: cutting edge; unstable features allowed.">Channel</div
-				><div
-					><input type=radio name=version id=version-stable value=stable checked><label for=version-stable title="Use the stable channel">Stable</label
-					><input type=radio name=version id=version-beta value=beta><label for=version-beta title="Use the beta channel">Beta</label
-					><input type=radio name=version id=version-nightly value=nightly><label for=version-nightly title="Use the nightly channel">Nightly</label
-				></div
-			></div
-			><wbr><div class=right-c-e
-				><button type=button id=configure-editor><span>Configure editor</span></button
-				><div class=dropdown>
-					<p><label for=keyboard>Keyboard bindings:</label>
-					<select name=keyboard id=keyboard>
-						<option>Ace</option>
-						<option>Emacs</option>
-						<option>Vim</option>
-					</select>
-					<p><label for=themes>Theme:</label>
-					<select name=themes id=themes></select>
-					<p><label for=asm-flavor>Asm Flavor:</label>
-					<select name=asm-flavor id=asm-flavor>
-						<option>att</option>
-						<option>intel</option>
-					</select>
-				</div
-			></div>
+                ><div
+                    ><input type=radio name=version id=version-stable value=stable checked><label for=version-stable title="Use the stable channel">Stable</label
+                    ><input type=radio name=version id=version-beta value=beta><label for=version-beta title="Use the beta channel">Beta</label
+                    ><input type=radio name=version id=version-nightly value=nightly><label for=version-nightly title="Use the nightly channel">Nightly</label
+                ></div
+            ></div
+            ><wbr><div class=right-c-e
+                ><button type=button id=configure-editor><span>Configure editor</span></button
+                ><div class=dropdown>
+                    <p><label for=keyboard>Keyboard bindings:</label>
+                    <select name=keyboard id=keyboard>
+                        <option>Ace</option>
+                        <option>Emacs</option>
+                        <option>Vim</option>
+                    </select>
+                    <p><label for=themes>Theme:</label>
+                    <select name=themes id=themes></select>
+                    <p><label for=asm-flavor>Asm Flavor:</label>
+                    <select name=asm-flavor id=asm-flavor>
+                        <option>att</option>
+                        <option>intel</option>
+                    </select>
+                </div
+            ></div>
         </form>
         <main>
             <div id=editor>fn main() {

--- a/static/web.js
+++ b/static/web.js
@@ -665,6 +665,7 @@
         };
 
         mirButton.onclick = function() {
+            document.getElementById("version-nightly").checked = true;
             compile("mir", result, session.getValue(), getRadioValue("version"),
                      getRadioValue("optimize"), mirButton);
         };

--- a/static/web.js
+++ b/static/web.js
@@ -465,6 +465,7 @@
     var evaluateButton;
     var asmButton;
     var irButton;
+    var mirButton;
     var formatButton;
     var shareButton;
     var gistButton;
@@ -542,6 +543,7 @@
         evaluateButton = document.getElementById("evaluate");
         asmButton = document.getElementById("asm");
         irButton = document.getElementById("llvm-ir");
+        mirButton = document.getElementById("mir");
         formatButton = document.getElementById("format");
         shareButton = document.getElementById("share");
         gistButton = document.getElementById("gist");
@@ -660,6 +662,11 @@
         irButton.onclick = function() {
             compile("llvm-ir", result, session.getValue(), getRadioValue("version"),
                      getRadioValue("optimize"), irButton);
+        };
+
+        mirButton.onclick = function() {
+            compile("mir", result, session.getValue(), getRadioValue("version"),
+                     getRadioValue("optimize"), mirButton);
         };
 
         formatButton.onclick = function() {

--- a/web.py
+++ b/web.py
@@ -112,8 +112,6 @@ def compile(emit, optimize, version, color, syntax):
         args.append("-C")
         args.append("llvm-args=-x86-asm-syntax=%s" % syntax)
     if emit == "mir":
-        version = "nightly"     # shhh...
-        # (FIXME: remove after --unpretty=mir hits beta/stable)
         args.append("-Zunstable-options")
         args.append("--unpretty=mir")
     else:


### PR DESCRIPTION
This adds another "MIR" button next to "LLVM IR", which invokes `rustc --unpretty mir`. Since that only works in nightly, this currently ignores the channel selection.

Closes #154