### PR TITLE
Set RUST_BACKTRACE=1 everywhere

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-TERM=xterm rustc - -o ./out "$@"
+RUST_BACKTRACE=1 TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec cat out

--- a/bin/evaluate.sh
+++ b/bin/evaluate.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+export RUST_BACKTRACE=1
+
 TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 if [ "${*#*--test}" != "$*" ] && [ "${*#*--color=always}" != "$*" ]; then


### PR DESCRIPTION
This makes debugging panics (and especially ICEs) much simpler.