### PR TITLE
Update ace to 1.2.3

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -10,8 +10,14 @@
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ace.js" charset="utf-8"></script>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ext-themelist.js" charset="utf-8"></script>
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ace.js"
+                integrity="sha512-lp7lBcKlkYx0jlja+DwHOHRk8LPaxvP8MuTlxAFgOpUYNib+59G1IwsxLBIFYwrkxYaBmn/oF9TWtDSEY5Ph+w=="
+                crossorigin="anonymous"
+                charset="utf-8"></script>
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ext-themelist.js"
+                integrity="sha512-F7PRyMnRbqZEM6kS5YAvxekuwessnK2eIJ3hnxTqpD+5e8lz5K6aa4pH0puO2Gip1CYgCHjvdgXS5+64lsAXog=="
+                crossorigin="anonymous"
+                charset="utf-8"></script>
         <script src="web.js?11"></script>
     </head>
     <body>

--- a/static/web.html
+++ b/static/web.html
@@ -10,8 +10,8 @@
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
-        <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ace.js" charset="utf-8"></script>
-        <script src="https://cdn.jsdelivr.net/ace/1.1.9/min/ext-themelist.js" charset="utf-8"></script>
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ace.js" charset="utf-8"></script>
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ext-themelist.js" charset="utf-8"></script>
         <script src="web.js?11"></script>
     </head>
     <body>


### PR DESCRIPTION
Fixes #180.

Here's a example of something that is currently highlighted incorrectly on playpen and fixed by the update:
```
fn main() {
    let test = 1_2.3E+7f32;
}
```

This also adds Subresource Integrity (SRI) hashes for external javascript files, although ace will pull down additional javascript files from the CDN when setting the mode and theme that don't seem to be validated.