### PR TITLE
Hyperlink line numbers ( continuation of #143 )

### DIFF
--- a/static/web.css
+++ b/static/web.css
@@ -541,6 +541,12 @@ button[disabled]:last-child::before {
     border-bottom: 1px dashed rgba(0, 0, 0, 0.25);
 }
 
+a.linejump {
+    cursor: pointer;
+    color: #97248D;
+    border-bottom: thin #97248D dotted;
+}
+
 .ace_dark .rustc-output {
     border-bottom-color: rgba(255, 255, 255, 0.25);
 }

--- a/static/web.html
+++ b/static/web.html
@@ -6,15 +6,6 @@
         <!-- Bear in mind with the figure 720 that when the stable channel is added the toolbar will be full, and so any additions beyond that will necessitate change here or there. -->
         <meta name=viewport id=meta-viewport content="width=720">
         <script>if (screen.width > 720) { document.getElementById("meta-viewport").setAttribute('content', 'width=device-width'); }</script>
-        <script>
-            <!-- called on events from web.js -->
-            var old_range;
-            function editSel() { return window.ace.edit("editor").selection; }
-            function editRestore() { if (old_range) { editSel().setSelectionRange(old_range, false) } }
-            function editLine(r1) { var e = editSel(); e.clearSelection(); e.setSelectionAnchor(r1-1,0); e.selectLine() }
-            function editShow(r1,c1, r2,c2) { var e = editSel(); old_range = e.getRange(); e.clearSelection(); e.setSelectionAnchor(r1-1,c1-1); e.selectTo(r2-1,c2-1) }
-            function editGo(r1,c1) { var e = editSel(); e.moveCursorTo(r1-1,c1-1,false); old_range = undefined }
-        </script>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">

--- a/static/web.html
+++ b/static/web.html
@@ -6,6 +6,15 @@
         <!-- Bear in mind with the figure 720 that when the stable channel is added the toolbar will be full, and so any additions beyond that will necessitate change here or there. -->
         <meta name=viewport id=meta-viewport content="width=720">
         <script>if (screen.width > 720) { document.getElementById("meta-viewport").setAttribute('content', 'width=device-width'); }</script>
+        <script>
+            <!-- called on events from web.js -->
+            var old_range;
+            function editSel() { return window.ace.edit("editor").selection; }
+            function editRestore() { if (old_range) { editSel().setSelectionRange(old_range, false) } }
+            function editLine(r1) { var e = editSel(); e.clearSelection(); e.setSelectionAnchor(r1-1,0); e.selectLine() }
+            function editShow(r1,c1, r2,c2) { var e = editSel(); old_range = e.getRange(); e.clearSelection(); e.setSelectionAnchor(r1-1,c1-1); e.selectTo(r2-1,c2-1) }
+            function editGo(r1,c1) { var e = editSel(); e.moveCursorTo(r1-1,c1-1,false); old_range = undefined }
+        </script>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700"/>
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">

--- a/static/web.js
+++ b/static/web.js
@@ -558,8 +558,8 @@
                      })
             .replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g,
                      function(text, code) {
-                         return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code
-                             + ">detailed explanation for " + code + "</a>";
+                         return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code +
+			     ">detailed explanation for " + code + "</a>";
                      })
             .replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
             .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)

--- a/static/web.js
+++ b/static/web.js
@@ -561,6 +561,7 @@
                          return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code
                              + ">detailed explanation for " + code + "</a>";
                      })
+            .replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
             .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
             .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine);
     }

--- a/static/web.js
+++ b/static/web.js
@@ -541,6 +541,10 @@
             return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + code + "</a>]";
         }).replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g, function(text, code) {
             return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + ">detailed explanation for " + code + "</a>";
+        }).replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, function(text, r1,c1, r2,c2) {
+            return "<a onmouseout=\"javascript:editRestore()\" onmouseover=\"javascript:editShow("+r1+","+c1+", "+r2+","+c2+")\" href=\"javascript:editGo("+r1+","+c1+")\">" + text + "</a>";
+        }).replace(/^&lt;anon&gt;:(\d+) /mg, function (text, r1) {
+            return "<a href=\"javascript:editLine(" + r1 + ")\">" + text + "</a>";
         });
     }
 

--- a/static/web.js
+++ b/static/web.js
@@ -723,3 +723,12 @@
 
     }, false);
 }());
+
+
+// called via javascript:fn events from formatCompilerOutput
+var old_range;
+function editSel() { return window.ace.edit("editor").selection; }
+function editRestore() { if (old_range) { editSel().setSelectionRange(old_range, false) } }
+function editLine(r1) { var e = editSel(); e.clearSelection(); e.setSelectionAnchor(r1-1,0); e.selectLine() }
+function editShow(r1,c1, r2,c2) { var e = editSel(); old_range = e.getRange(); e.clearSelection(); e.setSelectionAnchor(r1-1,c1-1); e.selectTo(r2-1,c2-1) }
+function editGo(r1,c1) { var e = editSel(); e.moveCursorTo(r1-1,c1-1,false); old_range = undefined }

--- a/static/web.js
+++ b/static/web.js
@@ -152,11 +152,7 @@
                 if ("program" in object) {
                     samp = document.createElement("samp");
                     samp.className = "output";
-                    if (test) {
-                        samp.innerHTML = ansi2html(object.program);
-                    } else {
-                        samp.textContent = object.program;
-                    }
+                    samp.innerHTML = formatCompilerOutput(object.program);
                     pre = document.createElement("pre");
                     pre.appendChild(samp);
                     result.appendChild(pre);

--- a/static/web.js
+++ b/static/web.js
@@ -537,12 +537,14 @@
     }
 
     function jumpToLine(text, r1) {
-        return "<a href=\"javascript:editLine(" + r1 + ")\">" + text + "</a>";
+        return "<a onclick=\"javascript:editGo(" + r1 + ",1)\"" +
+            " onmouseover=\"javascript:editShowLine("+r1+")\"" +
+            " onmouseout=\"javascript:editRestore()\">" + text + "</a>";
     }
 
     function jumpToRegion(text, r1,c1, r2,c2) {
-        return "<a href=\"javascript:editGo("+r1+","+c1+")\"" +
-            " onmouseover=\"javascript:editShow("+r1+","+c1+", "+r2+","+c2+")\"" +
+        return "<a onclick=\"javascript:editGo("+r1+","+c1+")\"" +
+            " onmouseover=\"javascript:editShowRegion("+r1+","+c1+", "+r2+","+c2+")\"" +
             " onmouseout=\"javascript:editRestore()\">" + text + "</a>";
     }
 
@@ -558,7 +560,7 @@
                              + ">detailed explanation for " + code + "</a>";
                      })
             .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
-            .replace(/^&lt;anon&gt;:(\d+) /mg, jumpToLine);
+            .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine);
     }
 
     addEventListener("DOMContentLoaded", function() {
@@ -741,33 +743,37 @@
 // called via javascript:fn events from formatCompilerOutput
 var old_range;
 
-function editSel() {
-    return window.ace.edit("editor").selection;
+function editorGet() {
+    return window.ace.edit("editor");
 }
 
 function editGo(r1,c1) {
-    var e = editSel();
-    e.moveCursorTo(r1-1,c1-1,false);
+    var e = editorGet();
     old_range = undefined;
+    e.focus();
+    e.selection.clearSelection();
+    e.selection.moveCursorTo(r1-1, c1-1, false);
 }
 
 function editRestore() {
     if (old_range) {
-        editSel().setSelectionRange(old_range, false);
+        editorGet().selection.setSelectionRange(old_range, false);
     }
 }
 
-function editShow(r1,c1, r2,c2) {
-    var e = editSel();
-    old_range = e.getRange();
-    e.clearSelection();
-    e.setSelectionAnchor(r1-1,c1-1);
-    e.selectTo(r2-1,c2-1);
+function editShowRegion(r1,c1, r2,c2) {
+    var es = editorGet().selection;
+    old_range = es.getRange();
+    es.clearSelection();
+    es.setSelectionAnchor(r1-1, c1-1);
+    es.selectTo(r2-1, c2-1);
 }
 
-function editLine(r1) {
-    var e = editSel();
-    e.clearSelection();
-    e.setSelectionAnchor(r1-1,0);
-    e.selectLine();
+function editShowLine(r1) {
+    var es = editorGet().selection;
+    old_range = es.getRange();
+    es.clearSelection();
+    es.moveCursorTo(r1-1, 0);
+    es.moveCursorLineEnd();
+    es.selectTo(r1-1, 0);
 }

--- a/static/web.js
+++ b/static/web.js
@@ -539,13 +539,15 @@
     function jumpToLine(text, r1) {
         return "<a onclick=\"javascript:editGo(" + r1 + ",1)\"" +
             " onmouseover=\"javascript:editShowLine("+r1+")\"" +
-            " onmouseout=\"javascript:editRestore()\">" + text + "</a>";
+            " onmouseout=\"javascript:editRestore()\"" +
+            " class=\"linejump\">" + text + "</a>";
     }
 
     function jumpToRegion(text, r1,c1, r2,c2) {
         return "<a onclick=\"javascript:editGo("+r1+","+c1+")\"" +
             " onmouseover=\"javascript:editShowRegion("+r1+","+c1+", "+r2+","+c2+")\"" +
-            " onmouseout=\"javascript:editRestore()\">" + text + "</a>";
+            " onmouseout=\"javascript:editRestore()\"" +
+            " class=\"linejump\">" + text + "</a>";
     }
 
     function formatCompilerOutput(text) {

--- a/static/web.js
+++ b/static/web.js
@@ -740,8 +740,34 @@
 
 // called via javascript:fn events from formatCompilerOutput
 var old_range;
-function editSel() { return window.ace.edit("editor").selection; }
-function editRestore() { if (old_range) { editSel().setSelectionRange(old_range, false) } }
-function editLine(r1) { var e = editSel(); e.clearSelection(); e.setSelectionAnchor(r1-1,0); e.selectLine() }
-function editShow(r1,c1, r2,c2) { var e = editSel(); old_range = e.getRange(); e.clearSelection(); e.setSelectionAnchor(r1-1,c1-1); e.selectTo(r2-1,c2-1) }
-function editGo(r1,c1) { var e = editSel(); e.moveCursorTo(r1-1,c1-1,false); old_range = undefined }
+
+function editSel() {
+    return window.ace.edit("editor").selection;
+}
+
+function editGo(r1,c1) {
+    var e = editSel();
+    e.moveCursorTo(r1-1,c1-1,false);
+    old_range = undefined;
+}
+
+function editRestore() {
+    if (old_range) {
+        editSel().setSelectionRange(old_range, false);
+    }
+}
+
+function editShow(r1,c1, r2,c2) {
+    var e = editSel();
+    old_range = e.getRange();
+    e.clearSelection();
+    e.setSelectionAnchor(r1-1,c1-1);
+    e.selectTo(r2-1,c2-1);
+}
+
+function editLine(r1) {
+    var e = editSel();
+    e.clearSelection();
+    e.setSelectionAnchor(r1-1,0);
+    e.selectLine();
+}

--- a/static/web.js
+++ b/static/web.js
@@ -536,10 +536,13 @@
             });
     }
 
-    //If mouse clicks on eg. "<anon>:3" then cursor is moved to start of that line
-    //If mouse hovers over that, temporarily show that line into view by 
-    //selecting it entirely and cursor move to the beginning of it
-    //moves back to original view when mouse moved away
+    //This affects how mouse acts on the program output.
+    //Screenshots here: https://github.com/rust-lang/rust-playpen/pull/192#issue-145465630
+    //If mouse hovers on eg. "<anon>:3", temporarily show that line(3) into view by 
+    //selecting it entirely and move editor's cursor to the beginning of it;
+    //Moves back to original view when mouse moved away.
+    //If mouse left click on eg. "<anon>:3" then the editor's cursor is moved
+    //to the beginning of that line
     function jumpToLine(text, r1) {
         return "<a onclick=\"javascript:editGo(" + r1 + ",1)\"" +
             " onmouseover=\"javascript:editShowLine("+r1+")\"" +
@@ -548,8 +551,8 @@
     }
 
     //Similarly to jumpToLine, except this one acts on eg. "<anon>:2:31: 2:32"
-    //and thus selects a region on mouse hover, or sets cursor to the beginning
-    //of it when clicked
+    //and thus selects a region on mouse hover, or when clicked sets cursor to
+    //the beginning of region.
     function jumpToRegion(text, r1,c1, r2,c2) {
         return "<a onclick=\"javascript:editGo("+r1+","+c1+")\"" +
             " onmouseover=\"javascript:editShowRegion("+r1+","+c1+", "+r2+","+c2+")\"" +

--- a/static/web.js
+++ b/static/web.js
@@ -559,7 +559,7 @@
             .replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g,
                      function(text, code) {
                          return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code +
-			     ">detailed explanation for " + code + "</a>";
+                             ">detailed explanation for " + code + "</a>";
                      })
             .replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
             .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
@@ -584,6 +584,7 @@
         editor = ace.edit("editor");
         set_result.editor = editor;
         editor.$blockScrolling = Infinity;
+        editor.setAnimatedScroll(true);
         session = editor.getSession();
         themelist = ace.require("ace/ext/themelist");
 
@@ -756,27 +757,43 @@ function editGo(r1,c1) {
     old_range = undefined;
     e.focus();
     e.selection.clearSelection();
+    e.scrollToLine(r1-1, true, true);
     e.selection.moveCursorTo(r1-1, c1-1, false);
 }
 
 function editRestore() {
     if (old_range) {
-        editorGet().selection.setSelectionRange(old_range, false);
+        var e = editorGet();
+        e.selection.setSelectionRange(old_range, false);
+        var mid = (e.getFirstVisibleRow() + e.getLastVisibleRow()) / 2;
+        var intmid = Math.round(mid);
+        var extra = (intmid - mid)*2 + 2;
+        var up = e.getFirstVisibleRow() - old_range.start.row + extra;
+        var down = old_range.end.row - e.getLastVisibleRow() + extra;
+        if (up > 0) {
+            e.scrollToLine(mid - up, true, true);
+        } else if (down > 0) {
+            e.scrollToLine(mid + down, true, true);
+        } // else visible enough
     }
 }
 
 function editShowRegion(r1,c1, r2,c2) {
-    var es = editorGet().selection;
+    var e = editorGet();
+    var es = e.selection;
     old_range = es.getRange();
     es.clearSelection();
+    e.scrollToLine(Math.round((r1 + r2) / 2), true, true);
     es.setSelectionAnchor(r1-1, c1-1);
     es.selectTo(r2-1, c2-1);
 }
 
 function editShowLine(r1) {
-    var es = editorGet().selection;
+    var e = editorGet();
+    var es = e.selection;
     old_range = es.getRange();
     es.clearSelection();
+    e.scrollToLine(r1, true, true);
     es.moveCursorTo(r1-1, 0);
     es.moveCursorLineEnd();
     es.selectTo(r1-1, 0);

--- a/static/web.js
+++ b/static/web.js
@@ -583,6 +583,7 @@
         themes = document.getElementById("themes");
         editor = ace.edit("editor");
         set_result.editor = editor;
+        editor.$blockScrolling = Infinity;
         session = editor.getSession();
         themelist = ace.require("ace/ext/themelist");
 

--- a/static/web.js
+++ b/static/web.js
@@ -551,19 +551,13 @@
     }
 
     function formatCompilerOutput(text) {
-        return ansi2html(text)
-            .replace(/\[(E\d\d\d\d)\]/g,
-                     function(text, code) {
-                         return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + code + "</a>]";
-                     })
-            .replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g,
-                     function(text, code) {
-                         return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code +
-                             ">detailed explanation for " + code + "</a>";
-                     })
-            .replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
-            .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
-            .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine);
+        return ansi2html(text).replace(/\[(E\d\d\d\d)\]/g, function(text, code) {
+            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + code + "</a>]";
+        }).replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g, function(text, code) {
+            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + ">detailed explanation for " + code + "</a>";
+        }).replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
+        .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
+        .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine);
     }
 
     addEventListener("DOMContentLoaded", function() {

--- a/static/web.js
+++ b/static/web.js
@@ -536,6 +536,10 @@
             });
     }
 
+    //If mouse clicks on eg. "<anon>:3" then cursor is moved to start of that line
+    //If mouse hovers over that, temporarily show that line into view by 
+    //selecting it entirely and cursor move to the beginning of it
+    //moves back to original view when mouse moved away
     function jumpToLine(text, r1) {
         return "<a onclick=\"javascript:editGo(" + r1 + ",1)\"" +
             " onmouseover=\"javascript:editShowLine("+r1+")\"" +
@@ -543,6 +547,9 @@
             " class=\"linejump\">" + text + "</a>";
     }
 
+    //Similarly to jumpToLine, except this one acts on eg. "<anon>:2:31: 2:32"
+    //and thus selects a region on mouse hover, or sets cursor to the beginning
+    //of it when clicked
     function jumpToRegion(text, r1,c1, r2,c2) {
         return "<a onclick=\"javascript:editGo("+r1+","+c1+")\"" +
             " onmouseover=\"javascript:editShowRegion("+r1+","+c1+", "+r2+","+c2+")\"" +

--- a/static/web.js
+++ b/static/web.js
@@ -536,16 +536,29 @@
             });
     }
 
+    function jumpToLine(text, r1) {
+        return "<a href=\"javascript:editLine(" + r1 + ")\">" + text + "</a>";
+    }
+
+    function jumpToRegion(text, r1,c1, r2,c2) {
+        return "<a href=\"javascript:editGo("+r1+","+c1+")\"" +
+            " onmouseover=\"javascript:editShow("+r1+","+c1+", "+r2+","+c2+")\"" +
+            " onmouseout=\"javascript:editRestore()\">" + text + "</a>";
+    }
+
     function formatCompilerOutput(text) {
-        return ansi2html(text).replace(/\[(E\d\d\d\d)\]/g, function(text, code) {
-            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + code + "</a>]";
-        }).replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g, function(text, code) {
-            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + ">detailed explanation for " + code + "</a>";
-        }).replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, function(text, r1,c1, r2,c2) {
-            return "<a onmouseout=\"javascript:editRestore()\" onmouseover=\"javascript:editShow("+r1+","+c1+", "+r2+","+c2+")\" href=\"javascript:editGo("+r1+","+c1+")\">" + text + "</a>";
-        }).replace(/^&lt;anon&gt;:(\d+) /mg, function (text, r1) {
-            return "<a href=\"javascript:editLine(" + r1 + ")\">" + text + "</a>";
-        });
+        return ansi2html(text)
+            .replace(/\[(E\d\d\d\d)\]/g,
+                     function(text, code) {
+                         return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + code + "</a>]";
+                     })
+            .replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g,
+                     function(text, code) {
+                         return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code
+                             + ">detailed explanation for " + code + "</a>";
+                     })
+            .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
+            .replace(/^&lt;anon&gt;:(\d+) /mg, jumpToLine);
     }
 
     addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
This is a continuation of #143
Hyperlink line numbers, **Features:** 
* temporarily move into view the line(or region) that the mouse hovers on eg. line: `<anon>:3` region: `<anon>:3:5: 3:10`
* restore view when mouse doesn't hover on such lines. (wherever you left your cursor while editing)
* when left clicked, move cursor at the beginning of the specified line(or region)

In this PR I tried to address [Alex's comments](https://github.com/rust-lang/rust-playpen/pull/143/files#r35566375).
All the [hard work](https://github.com/rust-lang/rust-playpen/pull/143) is actually done by @mcast ! Much appreciated!

Screenshots (look at **mouse hover**):
![1](https://cloud.githubusercontent.com/assets/17984080/14231360/e6328f46-f980-11e5-967f-eaede6b42adc.png)
![2](https://cloud.githubusercontent.com/assets/17984080/14231361/e8c02016-f980-11e5-82ea-0860c95a144f.png)
![3](https://cloud.githubusercontent.com/assets/17984080/14231362/eab337dc-f980-11e5-942b-3cd17b13afed.png)
![4](https://cloud.githubusercontent.com/assets/17984080/14231364/ed2831de-f980-11e5-8090-7ab16a5aab66.png)


And this is **mouse left click**:
![5click](https://cloud.githubusercontent.com/assets/17984080/14231365/f2c77aa0-f980-11e5-9f29-16113c7165e2.png)
![6click](https://cloud.githubusercontent.com/assets/17984080/14231367/f49075a8-f980-11e5-991a-624a80d3db2d.png)
![7click](https://cloud.githubusercontent.com/assets/17984080/14231398/cfcdae92-f981-11e5-9e82-06aa4907b402.png)

**EDIT:** fixed last screenshot which wasn't showing the cursor(blinking - timing)