### PR TITLE
fix: backtrace wasn't properly passed to [Format]

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -187,8 +187,8 @@
         }, button, "Compiling…", result);
     }
 
-    function format(result, session, version, button) {
-        send("format.json", {code: session.getValue(), version: version}, function(object) {
+    function format(result, session, version, button, optimize, backtrace) {
+        send("format.json", {code: session.getValue(), version: version, optimize: optimize, backtrace: backtrace}, function(object) {
             if ("error" in object) {
                 set_result(result, "<pre class=highlight><samp class=rustc-errors></samp></pre>");
                 result.firstChild.firstChild.innerHTML = formatCompilerOutput(object.error);
@@ -693,7 +693,8 @@
         };
 
         formatButton.onclick = function() {
-            format(result, session, getRadioValue("version"), formatButton);
+            format(result, session, getRadioValue("version"), formatButton,
+                   getRadioValue("optimize"), backtrace.value);
         };
 
         shareButton.onclick = function() {


### PR DESCRIPTION
To test this, press Format button on this sample code to cause a rustfmt panic:
https://play.rust-lang.org/?gist=8b133106dd19821a06ee68be3a922ebe&version=stable&backtrace=1

This is a fix for PR #191