### PR TITLE
Focus editor via Esc or Enter key(s) especially after a Run.

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -637,6 +637,17 @@
             editor.resize();
         });
 
+        //This helps re-focus editor after a Run or any other action that caused
+        //editor to lose focus. Just press Enter or Esc key to focus editor.
+        //Without this, you'd most likely have to LMB somewhere in the editor
+        //area which would change the location of its cursor to where you clicked.
+        addEventListener("keyup", function(e) {
+            if ((document.body == document.activeElement) //needed to avoid when editor has focus already
+                && (13 == e.keyCode || 27 == e.keyCode)) { //Enter or Escape keys
+                editor.focus();
+            }
+        });
+
         session.on("change", function() {
             var code = session.getValue();
             optionalLocalStorageSetItem("code", code);

--- a/static/web.js
+++ b/static/web.js
@@ -642,8 +642,8 @@
         //Without this, you'd most likely have to LMB somewhere in the editor
         //area which would change the location of its cursor to where you clicked.
         addEventListener("keyup", function(e) {
-            if ((document.body == document.activeElement) //needed to avoid when editor has focus already
-                && (13 == e.keyCode || 27 == e.keyCode)) { //Enter or Escape keys
+            if ((document.body == document.activeElement) && //needed to avoid when editor has focus already
+                (13 == e.keyCode || 27 == e.keyCode)) { //Enter or Escape keys
                 editor.focus();
             }
         });


### PR DESCRIPTION
(unless already focused)

After eg. Run, quickly focus back to the editor by pressing either Esc or
Enter key.

Wanted effect:
* preserves cursor position in editor
(without this  you'd have to LMB(EDIT: LMB to exactly where the cursor is already), or Shift+Tab a variable number of times)

Side effect:
* clicking outside of editor area (eg. background) will allow you to
refocus editor via Esc/Enter
* **Ctrl+Enter** (to Run) is also affected in the sense that the **editor remains focused**, which differs from before(unfocused after Run).  (if this isn't wanted, we could either remove Enter, and leave just Esc key, or find another way to "eat"/ignore Enter key from Ctrl+Enter)

Unaffected:
* Esc/Enter do not affect/interfere with options selection within Settings.
* Esc/Enter have no effect when editor is already focused.
