### PR TITLE
detect nightly tests

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -489,7 +489,9 @@
 
     function updateEvaluateAction(code) {
         // A very simple pair of heuristics; there’s no point in doing more, IMO.
-        if (code.indexOf("fn main()") === -1 && code.indexOf("#[test]") !== -1) {
+        if ((code.indexOf("fn main()") === -1 ||
+             code.indexOf("fn main() {}") === 0 ) //on first line, just like the first Run from here generates them: https://doc.rust-lang.org/nightly/book/testing.html
+            && code.indexOf("#[test]") !== -1) {
             evaluateButton.textContent = "Test";
             evaluateAction = "test";
         } else {

--- a/static/web.js
+++ b/static/web.js
@@ -490,8 +490,8 @@
     function updateEvaluateAction(code) {
         // A very simple pair of heuristics; there’s no point in doing more, IMO.
         if ((code.indexOf("fn main()") === -1 ||
-             code.indexOf("fn main() {}") === 0 ) //on first line, just like the first Run from here generates them: https://doc.rust-lang.org/nightly/book/testing.html
-            && code.indexOf("#[test]") !== -1) {
+             code.indexOf("fn main() {}") === 0 ) && //on first line, just like the first Run from here generates them: https://doc.rust-lang.org/nightly/book/testing.html
+            code.indexOf("#[test]") !== -1) {
             evaluateButton.textContent = "Test";
             evaluateAction = "test";
         } else {


### PR DESCRIPTION
Dectects the test examples generated by nightly from here:
https://doc.rust-lang.org/nightly/book/testing.html
and runs them as Test, not as Run
(due to the embedded `main fn() {}` on the first line!)

This won't affect [stable](https://doc.rust-lang.org/stable/book/testing.html)(which wraps the test function within main)

To test this, go to [nightly book here](https://doc.rust-lang.org/nightly/book/testing.html) and pick the first example,
which would be [this](https://play.rust-lang.org/?code=fn%20main()%20%7B%7D%0A%23%5Btest%5D%0Afn%20it_works()%20%7B%0A%7D%0A)

```rust
fn main() {}
#[test]
fn it_works() {
}
```

`Run` button should become `Test` (with this PR)
