### PR TITLE
Add a Pygments lexer for MIR output, and fix HTML escaping.

### DIFF
--- a/mirlexer.py
+++ b/mirlexer.py
@@ -1,0 +1,63 @@
+from pygments.lexer import RegexLexer
+from pygments.token import Whitespace, Comment, Name, Keyword, Number, \
+    String, Punctuation, Operator, Text
+
+
+class RustMirLexer(RegexLexer):
+    name = 'Rust MIR'
+    filenames = []
+    aliases = ['rustmir']
+    mimetypes = ['text/x-rust-mir']
+
+    tokens = {
+        'root': [
+            (r'\s+', Whitespace),
+            (r'//(.*?)\n', Comment.Single),
+            (r'/\*', Comment.Multiline, 'comment'),
+            (r"bb\d+:", Name.Function),
+            (r'let\b', Keyword.Declaration),
+            (r'(fn|as|const|goto|mut|resume|return|unwind|asm!)\b', Keyword),
+            (r'(Box|Len|Add|Sub|Mul|Div|Rem|BitXor|BitAnd|BitOr|Shl|Shr|Eq|'
+             r'Lt|Le|Ne|Ge|Gt|Not|Neg|drop|switch|switchInt)\b', Name.Builtin),
+            (r'(true|false)\b', Keyword.Constant),
+            (r'(u8|u16|u32|u64|i8|i16|i32|i64|usize|isize|f32|f64|str|bool)\b',
+             Keyword.Type),
+            (r"""'(\\['"\\nrt]|\\x[0-7][0-9a-fA-F]|\\0"""
+             r"""|\\u\{[0-9a-fA-F]{1,6}\}|.)'""", String.Char),
+            (r"""b'(\\['"\\nrt]|\\x[0-9a-fA-F]{2}|\\0"""
+             r"""|\\u\{[0-9a-fA-F]{1,6}\}|.)'""", String.Char),
+            (r'[0-9][0-9_]*(\.[0-9_]+[eE][+\-]?[0-9_]+|'
+             r'\.[0-9_]*(?!\.)|[eE][+\-]?[0-9_]+)', Number.Float, 'number_lit'),
+            (r'[0-9][0-9_]*', Number.Integer, 'number_lit'),
+            (r'b"', String, 'bytestring'),
+            (r'"', String, 'string'),
+            (r"'(static|<.*?>|[a-zA-Z_]\w*)", Name.Attribute),
+            (r'[{}()\[\],.;]', Punctuation),
+            (r'[+\-*/%&|<>^!~@=:?]', Operator),
+            (r'[a-zA-Z_]\w*', Name),
+        ],
+        'comment': [
+            (r'[^*/]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline),
+        ],
+        'number_lit': [
+            (r'[ui](8|16|32|64|size)', Number, '#pop'),
+            (r'f(32|64)', Number, '#pop'),
+            (r'', Text, '#pop'),
+        ],
+        'string': [
+            (r'"', String, '#pop'),
+            (r"\\['\"\\nrt]|\\x[0-7][0-9a-fA-F]|\\0|\\u\{[0-9a-fA-F]{1,6}\}",
+             String.Escape),
+            (r'[^\\"]+', String),
+            (r'\\', String),
+        ],
+        'bytestring': [
+            (r'"', String, '#pop'),
+            (r"\\['\"\\nrt]|\\x[0-7][0-9a-fA-F]|\\0", String.Escape),
+            (r'[^\\"]+', String),
+            (r'\\', String),
+        ],
+    }

--- a/web.py
+++ b/web.py
@@ -9,6 +9,7 @@ from bottle import get, request, response, route, run, static_file
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import GasLexer, LlvmLexer
+from mirlexer import RustMirLexer
 
 import playpen
 
@@ -153,7 +154,7 @@ def compile(emit, optimize, version, color, syntax, backtrace_str):
         elif emit == "llvm-ir":
             return {"result": highlight(split[1].decode(), LlvmLexer(), HtmlFormatter(nowrap=True))}
         else:
-            return {"result": split[1].decode()}
+            return {"result": highlight(split[1].decode(), RustMirLexer(), HtmlFormatter(nowrap=True))}
 
 os.chdir(sys.path[0])
 run(host='0.0.0.0', port=80, server='cherrypy')


### PR DESCRIPTION
Also fixes the problem of insufficient HTML escaping of MIR output
by neither highlighting nor escaping it.