### PR TITLE
Focus back on editor after clicking evaluate

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -725,6 +725,7 @@
 
         evaluateButton.onclick = function() {
             doEvaluate(true);
+            editor.focus();
         };
 
         editor.commands.addCommand({


### PR DESCRIPTION
Fix for #210.

Simply adds `editor.focus()` onto the `onclick` handler for the evaluate button.

I also experimented with automatically focusing when typing (noticed some of this logic was already there), returning focus when pressing any button, etc, but this seemed like the most intuitive option and doesn't break tabbing or anything more intrusive.