### PR TITLE
Open compiler explain links in a new window/tab by default

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -586,9 +586,9 @@
 
     function formatCompilerOutput(text) {
         return ansi2html(text).replace(/\[(--explain )?(E\d\d\d\d)\]/g, function(text, prefix, code) {
-            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_new>" + (prefix ? prefix : "") + code + "</a>]";
+            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_blank>" + (prefix ? prefix : "") + code + "</a>]";
         }).replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g, function(text, code) {
-            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_new>detailed explanation for " + code + "</a>";
+            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_blank>detailed explanation for " + code + "</a>";
         }).replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
         .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
         .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine)

--- a/static/web.js
+++ b/static/web.js
@@ -586,9 +586,9 @@
 
     function formatCompilerOutput(text) {
         return ansi2html(text).replace(/\[(--explain )?(E\d\d\d\d)\]/g, function(text, prefix, code) {
-            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + ">" + (prefix ? prefix : "") + code + "</a>]";
+            return "[<a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_new>" + (prefix ? prefix : "") + code + "</a>]";
         }).replace(/run `rustc --explain (E\d\d\d\d)` to see a detailed explanation/g, function(text, code) {
-            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + ">detailed explanation for " + code + "</a>";
+            return "see the <a href=https://doc.rust-lang.org/error-index.html#" + code + " target=_new>detailed explanation for " + code + "</a>";
         }).replace(/&lt;anon&gt;:(\d+)$/mg, jumpToLine) // panicked at 'foo', $&
         .replace(/^&lt;anon&gt;:(\d+):(\d+):\s+(\d+):(\d+)/mg, jumpToRegion)
         .replace(/^&lt;anon&gt;:(\d+)/mg, jumpToLine)


### PR DESCRIPTION
This irked me a little. I've added target="_new" to the formatted explain links so they open in a new window or tab rather than the page.