### PR TITLE
Make debugging playbot easier

### DIFF
--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -226,10 +226,11 @@ fn main() {
         let server = server.as_table().unwrap();
 
         for nick in server["nicks"].as_slice().unwrap() {
+            let server_addr = server["server"].as_str().unwrap();
             let conf = Config {
                 nickname: Some(String::from(nick.as_str().unwrap())),
                 nick_password: server.get("password").map(|val| String::from(val.as_str().unwrap())),
-                server: Some(String::from(server["server"].as_str().unwrap())),
+                server: Some(String::from(server_addr)),
                 port: server.get("port").map(|val| {
                     let port = val.as_integer().unwrap();
                     assert!(0 < port && port < u16::MAX as i64, "out of range for ports");
@@ -250,9 +251,11 @@ fn main() {
                 shorten_key: bitly_key.clone(),
                 cache: cache.clone(),
             };
-            threads.push(thread::spawn(move || {
+            threads.push(thread::Builder::new()
+                                         .name(format!("{}@{}", nick, server_addr))
+                                         .spawn(move || {
                 bot.main_loop();
-            }));
+            }).unwrap());
         }
     }
 

--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -167,7 +167,7 @@ fn main() {{
             }
 
             let command = &msg[1..];
-            info!("<{}> {}", from, command);
+            info!("{}: <{}> {}", chan, from, command);
             self.handle_cmd(chan, command);
         }
     }

--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -256,8 +256,8 @@ fn main() {
             threads.push(thread::Builder::new()
                                          .name(format!("{}@{}", nick, server_addr))
                                          .spawn(move || {
-                if let Err(e) = catch_unwind(AssertUnwindSafe(|| bot.main_loop())) {
-                    error!("{:?}", e);
+                if let Err(_) = catch_unwind(AssertUnwindSafe(|| bot.main_loop())) {
+                    error!("killing playbot due to previous error");
 
                     // Abort the whole process, killing the other threads. This should make
                     // debugging easier since the other bots don't keep running.


### PR DESCRIPTION
Sets names for threads, kills the whole process when a thread panics, and logs the channel from which playbot was talked to.

Closes #225