### PR TITLE
Fix message parsing

### DIFF
--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -162,7 +162,7 @@ fn main() {{
         if msg.starts_with(self.conn.current_nickname()) {
             let msg = &msg[self.conn.current_nickname().len()..];
 
-            if msg.len() <= 2 || !msg.starts_with(&[' ', ',', ':'] as &[char]) {
+            if msg.len() < 2 || !msg.starts_with(&[',', ':'] as &[char]) {
                 return;
             }
 


### PR DESCRIPTION
Right now, playbot ignores `playbot:1` while accepting `playbot:10`. In addition, it attempts to compile lines like `playbot foo` without requiring `:` or `,`, which gets awkward when trying to talk *about* playbot rather than invoke it. This PR fixes both problems.