### PR TITLE
Playbot: respond to invites if channel is in config

### DIFF
--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -205,6 +205,13 @@ fn main() {{
                         self.handle_privmsg(from, &msg);
                     }
                 },
+                Command::INVITE(_, ref to) => {
+                    if cloned.config().channels.as_ref().unwrap().contains(to) {
+                        if let Err(e) = self.conn.send_join(to) {
+                            error!("couldn't join {}: {}", to, e);
+                        }
+                    }
+                },
                 _ => {},
             }
         }


### PR DESCRIPTION
Allows ops to invite playbot back into the channel if it gets kicked,
which sometimes happens due to flood limits.