### PR TITLE
fix docker version < 1.12

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -25,7 +25,7 @@ impl Container {
                                    .arg("--pids-limit=20")
                                    .arg("--security-opt=no-new-privileges")
                                    .arg("--interactive")
-                                   .args(&env.iter().map(|&(ref k, ref v)| format!("-e{}={}", k, v)).collect::<Vec<_>>())
+                                   .args(&env.iter().map(|&(ref k, ref v)| format!("--env={}={}", k, v)).collect::<Vec<_>>())
                                    .arg(name)
                                    .arg(cmd)
                                    .stderr(Stdio::inherit())


### PR DESCRIPTION
This should fix #245 and fix rust-lang/rust-by-example#793.

I have tested the new playpen version with `docker 1.12` and verified that `--env=FOO=bar` works on `docker 1.11` (something like `./docker run --env=ABC=foo -it ubuntu`) so I'm pretty confident that this should fix the issues.