### PR TITLE
print rustc version before compiling

### DIFF
--- a/docker/bin/compile.sh
+++ b/docker/bin/compile.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+rustc --version
+
 RUST_NEW_ERROR_FORMAT=1 TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 exec cat out

--- a/docker/bin/evaluate.sh
+++ b/docker/bin/evaluate.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+rustc --version
+
 RUST_NEW_ERROR_FORMAT=1 TERM=xterm rustc - -o ./out "$@"
 printf '\377' # 255 in octal
 if [ "${*#*--test}" != "$*" ] && [ "${*#*--color=always}" != "$*" ]; then


### PR DESCRIPTION
This PR prints the version of the compiler before executing it.

This change may potentially be a bit controversial so you may want to consider this as some kind of RFC, however I think it's nice to get confirmation of the rust version used and the additional line of output does not really distract from the actual output (Although the situation may be a bit different for [rust-lang/rust-by-example](https://github.com/rust-lang/rust-by-example/), I'm not completely sure how they use the playpen api). 

Fixes #241.

r? @alexcrichton 