### PR TITLE
Revert "update ace to 1.2.6"

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -10,12 +10,12 @@
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.6/min/ace.js"
-                integrity="sha512-Y/M43OHLyvSuqF2JuQU9RIerW7fH7i/h/7AokQPIXhoYiHIxKXYDCWcuyRSXiVCGGtnfYoIBklTZ4/t26Lrr/A=="
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ace.js"
+                integrity="sha512-lp7lBcKlkYx0jlja+DwHOHRk8LPaxvP8MuTlxAFgOpUYNib+59G1IwsxLBIFYwrkxYaBmn/oF9TWtDSEY5Ph+w=="
                 crossorigin="anonymous"
                 charset="utf-8"></script>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.6/min/ext-themelist.js"
-                integrity="sha512-ZdrBduTZxDAOqGKxKVuFtIVU0wD82q0HXnUEj8/KBHZ9DbQuuAjfMZ7yyBnh3vzkOtMQex9jj8EuypRD+KGNSA=="
+        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ext-themelist.js"
+                integrity="sha512-F7PRyMnRbqZEM6kS5YAvxekuwessnK2eIJ3hnxTqpD+5e8lz5K6aa4pH0puO2Gip1CYgCHjvdgXS5+64lsAXog=="
                 crossorigin="anonymous"
                 charset="utf-8"></script>
         <script src="web.js?12"></script>


### PR DESCRIPTION
This reverts commit 9cc8d06fe8e94777e51d85117ccc486504380e6b in order to undo the regression reported in https://github.com/rust-lang/rust-playpen/issues/262.

Should this close #262? If so, we should probably open another issue to track updating Ace without enabling auto-matching for single quotes.

r? @alexcrichton 