### PR TITLE
Hijack single quote (and update ace again)

### DIFF
--- a/static/web.html
+++ b/static/web.html
@@ -18,7 +18,7 @@
                 integrity="sha512-ZdrBduTZxDAOqGKxKVuFtIVU0wD82q0HXnUEj8/KBHZ9DbQuuAjfMZ7yyBnh3vzkOtMQex9jj8EuypRD+KGNSA=="
                 crossorigin="anonymous"
                 charset="utf-8"></script>
-        <script src="web.js?12"></script>
+        <script src="web.js?13"></script>
     </head>
     <body>
         <form id="control">

--- a/static/web.html
+++ b/static/web.html
@@ -10,12 +10,12 @@
         <!-- web.css and web.js need cache busting; increment the numbers when you make changes -->
         <link rel="stylesheet" href="web.css?5">
         <link rel="shortcut icon" href="https://doc.rust-lang.org/favicon.ico"/>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ace.js"
-                integrity="sha512-lp7lBcKlkYx0jlja+DwHOHRk8LPaxvP8MuTlxAFgOpUYNib+59G1IwsxLBIFYwrkxYaBmn/oF9TWtDSEY5Ph+w=="
+        <script src="https://cdn.jsdelivr.net/ace/1.2.6/min/ace.js"
+                integrity="sha512-Y/M43OHLyvSuqF2JuQU9RIerW7fH7i/h/7AokQPIXhoYiHIxKXYDCWcuyRSXiVCGGtnfYoIBklTZ4/t26Lrr/A=="
                 crossorigin="anonymous"
                 charset="utf-8"></script>
-        <script src="https://cdn.jsdelivr.net/ace/1.2.3/min/ext-themelist.js"
-                integrity="sha512-F7PRyMnRbqZEM6kS5YAvxekuwessnK2eIJ3hnxTqpD+5e8lz5K6aa4pH0puO2Gip1CYgCHjvdgXS5+64lsAXog=="
+        <script src="https://cdn.jsdelivr.net/ace/1.2.6/min/ext-themelist.js"
+                integrity="sha512-ZdrBduTZxDAOqGKxKVuFtIVU0wD82q0HXnUEj8/KBHZ9DbQuuAjfMZ7yyBnh3vzkOtMQex9jj8EuypRD+KGNSA=="
                 crossorigin="anonymous"
                 charset="utf-8"></script>
         <script src="web.js?12"></script>


### PR DESCRIPTION
This PR updates ACE to 1.2.6 once again. It works around the previously encountered issue #262 (autopairing of single quotes).

I believe that the undesired behaviour was introduced in ajaxorg/ace@b2e85158bcf3e0e72fc6856701052b9594be1a93 on the ace side. A proper fix on the ace side seems to be non-trivial, however just patching ace to never autopair single quotes look like it could be easily done.

To avoid having to fork, build and deploy ace ourselves in the case of the easy fix (or an upstreamed fix if we don't want to wait an indeterminate amount of months for the next ace release), I implemented a workaround in our JavaScript which prevents the autopair behaviour for single quotes by hijacking single quote as a hotkey (see the comments in the workaround).

If it would be acceptable / preferable to build and deploy ace ourselves, I can also send a PR to that regard.

Note that this was tested on an english keyboard layout, where single quote does not require any modifier keys. It would be good if someone with a keyboard layout which requires a modifier key for single quote could test this patch as well.

These changes are deployed at https://dl.timnn.me/54acabe206c95f52/web.html, for anyone to easily try / test them.

Fixes #265.

r? @alexcrichton 

cc @bluss, @solson