### PR TITLE
fix nightly highlighting

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -549,12 +549,12 @@
                 return '<span class=ansi-' + COLOR_CODES[+colorCode] + '>' + text + '</span>';
             }).replace(/\x1b\[1m([^\x1b]*)(?:\x1b\(B)?\x1b\[0?m/g, function(original, text) {
                 return "<strong>" + text + "</strong>";
-            }).replace(/(?:\x1b\(B)?\x1b\[0m/g, '');
+            }).replace(/(?:\x1b\(B)?\x1b\[0?m/g, '');
     }
 
     //This affects how mouse acts on the program output.
     //Screenshots here: https://github.com/rust-lang/rust-playpen/pull/192#issue-145465630
-    //If mouse hovers on eg. "<anon>:3", temporarily show that line(3) into view by 
+    //If mouse hovers on eg. "<anon>:3", temporarily show that line(3) into view by
     //selecting it entirely and move editor's cursor to the beginning of it;
     //Moves back to original view when mouse moved away.
     //If mouse left click on eg. "<anon>:3" then the editor's cursor is moved


### PR DESCRIPTION
Fixes #271

rust-lang/rust#38660 (I assume) made a slight change to rustc's output, which was then no longer handled by the coloring regexes.

r? @alexcrichton 