### PR TITLE
playbot -- reduce maximum output size to 3000

### DIFF
--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -136,7 +136,7 @@ fn main() {{
         };
 
         let out = try!(self.run_code(&code, channel));
-        if out.len() > 5000 {
+        if out.len() > 3000 {
             return Ok(String::from("output too long, bailing out :("));
         }
 


### PR DESCRIPTION
Fix #276 

Short summary: playbot will exceed `RecvQ` limits on IRC and disconnect if given an input of 4997 (but seems to be fine with 4350, so the limit is some number between these two).  Either way, that's quite excessive for an IRC bot limited to two lines of output.

This PR reduces the maximum output to 3k bytes.