### PR TITLE
Add keyboard shortcut for Format and Share

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -804,10 +804,20 @@
             format(result, session, getRadioValue("version"), formatButton,
                    getRadioValue("optimize"), backtrace.value);
         };
+        editor.commands.addCommand({
+            name: "format",
+            exec: formatButton.onclick,
+            bindKey: {win: "Ctrl-Alt-F", mac: "Ctrl-Alt-F"}
+        });
 
         shareButton.onclick = function() {
             share(result, getRadioValue("version"), session.getValue(), shareButton, backtrace.value);
         };
+        editor.commands.addCommand({
+            name: "share",
+            exec: shareButton.onclick,
+            bindKey: {win: "Ctrl-Alt-S", mac: "Ctrl-Alt-S"}
+        });
 
         gistButton.onclick = function() {
             shareGist(result, getRadioValue("version"), session.getValue(), gistButton, backtrace.value);


### PR DESCRIPTION
Following a similar idea of #52, I'd like to add 2 shortcuts for Format and Share (ShortenUrl) buttons:
- `Ctrl-Alt-F` for the `Format` button
- `Ctrl-Alt-S` for the `Share` button

Tested with the docker local setup and Firefox/Chrome on LinuxMint 18

Current limitation:
- only work when editor is focused (similar to `Ctrl+Enter` for `Run`, but in that case the editor is focused when it's not)