### PR TITLE
Disable warnings for playbot

### DIFF
--- a/src/bin/playbot.rs
+++ b/src/bin/playbot.rs
@@ -121,7 +121,7 @@ impl Playbot {
             String::from(code)
         } else {
             format!(r#"
-#![allow(dead_code, unused_variables)]
+#![allow(warnings)]
 
 static VERSION: &'static str = "{version}";
 


### PR DESCRIPTION
Nobody ever wants to see warnings when using playbot, but when they do, they should use playbot-mini where fine grain control of the lints are available.